### PR TITLE
Only use parallel streams on known safe recipes

### DIFF
--- a/src/main/java/dev/shadowsoffire/fastsuite/AuxRecipeManager.java
+++ b/src/main/java/dev/shadowsoffire/fastsuite/AuxRecipeManager.java
@@ -1,13 +1,12 @@
 package dev.shadowsoffire.fastsuite;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Stopwatch;
+import net.minecraft.world.item.crafting.Ingredient;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import net.minecraft.resources.ResourceLocation;
@@ -36,14 +35,26 @@ public class AuxRecipeManager extends RecipeManager {
         return super.getRecipeFor(type, inv, level);
     }
 
+    private final Map<RecipeType<?>, CachedRecipeList<?, ?>> cachedRecipeListMap = new HashMap<>();
+
+    private <C extends Container, T extends Recipe<C>> CachedRecipeList<C, T> getCachedRecipeList(RecipeType<T> type) {
+        synchronized (cachedRecipeListMap) {
+            CachedRecipeList<C, T> list = (CachedRecipeList<C, T>)cachedRecipeListMap.get(type);
+            if(list == null) {
+                list = new CachedRecipeList<>(type, this.byType(type));
+                cachedRecipeListMap.put(type, list);
+            }
+            return list;
+        }
+    }
+
     @Override
     public <C extends Container, T extends Recipe<C>> Optional<T> getRecipeFor(RecipeType<T> type, C inv, Level level) {
         if (this.numRecipesOf(type) < FastSuite.MIN_SIZE_REQUIRED_FOR_THREADING || FastSuite.singleThreadedLookups.contains(type)) return super.getRecipeFor(type, inv, level);
         this.lockAllStacks(inv, true);
         try {
-            return StreamUtils.executeUntil(() -> this.byType(type).values().parallelStream().filter(recipe -> {
-                return recipe.matches(inv, level);
-            }).findFirst(), FastSuite.maxRecipeLookupTime, TimeUnit.SECONDS, Optional.empty(), () -> timeoutMsg(type));
+            var cachedRecipeList = getCachedRecipeList(type);
+            return cachedRecipeList.getRecipeFor(inv, level);
         }
         catch (Exception ex) {
             throw new RuntimeException(ex);
@@ -58,11 +69,8 @@ public class AuxRecipeManager extends RecipeManager {
         if (this.numRecipesOf(type) < FastSuite.MIN_SIZE_REQUIRED_FOR_THREADING || FastSuite.singleThreadedLookups.contains(type)) return super.getRecipesFor(type, inv, level);
         this.lockAllStacks(inv, true);
         try {
-            return StreamUtils.executeUntil(() -> this.byType(type).values().parallelStream().filter((recipe) -> {
-                return recipe.matches(inv, level);
-            }).sorted(Comparator.comparing((recipe) -> {
-                return recipe.getResultItem(level.registryAccess()).getDescriptionId();
-            })).collect(Collectors.toList()), FastSuite.maxRecipeLookupTime, TimeUnit.SECONDS, Collections.emptyList(), () -> timeoutMsg(type));
+            var cachedRecipeList = getCachedRecipeList(type);
+            return cachedRecipeList.getRecipesFor(inv, level);
         }
         catch (Exception ex) {
             throw new RuntimeException(ex);
@@ -93,5 +101,81 @@ public class AuxRecipeManager extends RecipeManager {
     private static String timeoutMsg(RecipeType<?> type) {
         return String.format("Multithreaded recipe lookup took longer than %d seconds - aborting and returning nothing. Consider blacklisting this recipe type (%s) in the config.", FastSuite.maxRecipeLookupTime,
             ForgeRegistries.RECIPE_TYPES.getKey(type));
+    }
+
+    private static class CachedRecipeList<C extends Container, T extends Recipe<C>> {
+        private final List<T> serialRecipes;
+        private final List<T> parallelRecipes;
+        private final RecipeType<T> type;
+
+        public CachedRecipeList(RecipeType<T> type, Map<ResourceLocation, T> recipeMap) {
+            this.type = type;
+            this.serialRecipes = new ArrayList<>();
+            this.parallelRecipes = new ArrayList<>();
+            Stopwatch watch = Stopwatch.createStarted();
+            for(Map.Entry<ResourceLocation, T> entry : recipeMap.entrySet()) {
+                if(isParallelRecipe(entry.getValue()))
+                    this.parallelRecipes.add(entry.getValue());
+                else
+                    this.serialRecipes.add(entry.getValue());
+            }
+            watch.stop();
+            FastSuite.LOGGER.info("Constructed recipe list for {} in {}. {}/{} recipes are parallelized.",
+                    ForgeRegistries.RECIPE_TYPES.getKey(type), watch, this.parallelRecipes.size(), recipeMap.size());
+        }
+
+        public Optional<T> getRecipeFor(C inv, Level level) {
+            Predicate<T> recipeFilter = (recipe) -> {
+                return recipe.matches(inv, level);
+            };
+            Optional<T> parRecipe = StreamUtils.executeUntil(() -> this.parallelRecipes.parallelStream().filter(recipeFilter).findFirst(), FastSuite.maxRecipeLookupTime, TimeUnit.SECONDS, Optional.empty(), () -> timeoutMsg(type));
+            if(parRecipe.isPresent())
+                return parRecipe;
+            // check serial recipes
+            for(T recipe : this.serialRecipes) {
+                if(recipe.matches(inv, level))
+                    return Optional.of(recipe);
+            }
+            return Optional.empty();
+        }
+
+        public List<T> getRecipesFor(C inv, Level level) {
+            Comparator<T> recipeSorter = Comparator.comparing((recipe) -> {
+                return recipe.getResultItem(level.registryAccess()).getDescriptionId();
+            });
+            Predicate<T> recipeFilter = (recipe) -> {
+                return recipe.matches(inv, level);
+            };
+            List<T> parallelList = StreamUtils.executeUntil(() -> this.parallelRecipes.parallelStream().filter(recipeFilter).sorted(recipeSorter).collect(Collectors.toCollection(ArrayList::new)), FastSuite.maxRecipeLookupTime, TimeUnit.SECONDS, Collections.emptyList(), () -> timeoutMsg(type));
+            parallelList.addAll(this.serialRecipes.stream().filter(recipeFilter).sorted(recipeSorter).toList());
+            return parallelList;
+        }
+
+        private static final Map<Class<?>, Boolean> parallelRecipeClassCache = Collections.synchronizedMap(new IdentityHashMap<>());
+        private static final Map<Class<?>, Boolean> ingredientClassCache = Collections.synchronizedMap(new IdentityHashMap<>());
+
+        private static boolean isParallelRecipeClass(Class<?> clz) {
+            // TODO: add modded whitelist
+            return parallelRecipeClassCache.computeIfAbsent(clz, c -> c.getName().startsWith("net.minecraft.world.item.crafting."));
+        }
+
+        private static boolean isValidIngredient(Ingredient ingredient) {
+            if(ingredient.isVanilla())
+                return true;
+            return ingredientClassCache.computeIfAbsent(ingredient.getClass(), clz -> {
+                return clz.getName().startsWith("net.minecraftforge.common.crafting.");
+            });
+        }
+
+        private boolean isParallelRecipe(T recipe) {
+            if(!isParallelRecipeClass(recipe.getClass()))
+                return false;
+            // now check ingredients
+            for(Ingredient ingredient : recipe.getIngredients()) {
+                if(!isValidIngredient(ingredient))
+                    return false;
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Since some recipe types/ingredients can throw CMEs, it is not safe to simply use a parallel stream on any recipe and call `matches`. This PR solves that issue by only applying parallelization to recipe types that are known to be safe. Currently, this is limited to vanilla recipe classes and ingredients, however even with such a strict check 96% of recipes are still parallelized in the ForgeCraft 1.20 pack.

Marked this as a draft since the code was written quickly and is intended to be a proof-of-concept.